### PR TITLE
Hungsean0419/mes 135 matrix utils and infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,100 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Package Manager
+
+- Uses `pnpm` as the package manager
+- Install dependencies: `pnpm install`
+- Setup git hooks: `pnpm prepare`
+
+### Development Server
+
+- Start dev server: `pnpm dev` (runs on http://localhost:5173)
+- Build for production: `pnpm build`
+- Start production server: `pnpm start`
+
+### Code Quality
+
+- Lint code: `pnpm lint`
+- Check types: `pnpm typecheck` (runs react-router typegen + tsc)
+- Format code: `pnpm format`
+- Check formatting: `pnpm format:check`
+
+## Architecture Overview
+
+### Framework & Stack
+
+- **React Router v7** with SSR enabled by default
+- **TypeScript** with strict mode
+- **Tailwind CSS v4** for styling
+- **Vite** for build tooling
+- **Matrix JS SDK** for Matrix protocol integration
+- **shadcn/ui** components (New York style)
+
+### Project Structure
+
+- `app/` - Main application code
+  - `routes/` - React Router file-based routing
+  - `components/` - Reusable React components
+    - `ui/` - shadcn/ui components
+    - `room-chat/` - Room-specific chat components
+    - `message/` - Message display components
+  - `lib/` - Utility libraries
+    - `matrix-api/` - Matrix protocol API wrappers
+  - `contexts/` - React context providers
+  - `hooks/` - Custom React hooks
+
+### Key Architectural Patterns
+
+#### Matrix Client Management
+
+- Central `Client` class in `app/lib/matrix-api/client.ts` wraps Matrix JS SDK
+- Handles token refresh, authentication state, and HTTP request wrapping
+- Global client instance exported for app-wide use
+- Room context (`app/contexts/room-context.tsx`) manages room state and Matrix events
+
+#### Routing Structure
+
+- File-based routing with React Router v7
+- Route naming convention: `_layout.route.tsx` pattern
+- Main layouts: `_dash.tsx` (dashboard), `_home.tsx` (home), `_index.tsx` (landing)
+
+#### Component Organization
+
+- UI components follow shadcn/ui patterns with Radix UI primitives
+- Custom components in feature-specific folders (room-chat, message)
+- Theme support via `next-themes` with dark mode default
+
+#### State Management
+
+- React Context for global state (rooms, auth)
+- Custom hooks for Matrix SDK integration
+- No external state management library
+
+### Import Aliases
+
+- `~/*` maps to `app/*`
+- Components use `~/components`, utils use `~/lib/utils`
+
+### Matrix Integration
+
+- Room management, messaging, and user authentication
+- Timeline handling with debounced message loading
+- Invite system and room settings
+- Bridge network icon support
+
+## Development Notes
+
+### Environment Setup
+
+- Node.js v22+ required
+- Pre-commit hooks configured with lint-staged
+- ESLint + Prettier for code quality
+
+### Docker Support
+
+- Dockerfile available for containerized deployment
+- Production builds serve on port 3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,84 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Invite system and room settings
 - Bridge network icon support
 
+## Planned Features
+
+### Contact Management System
+
+The application will include a contact management system with two main entities:
+
+#### ContactCard (contact-cards)
+
+Basic contact information cards containing:
+
+**Data Model:**
+
+```typescript
+interface ContactCard {
+  id: UUID; // Unique identifier
+  contact_name: string; // Contact name
+  nickname?: string; // Optional nickname
+  contact_avatar_url?: string; // Optional avatar URL
+}
+```
+
+**API Data Structures:**
+
+- `ContactCardResponse`: Complete data returned to frontend
+- `ContactCardCreate`: Input data for creating new contacts (excludes id)
+- `ContactCardUpdate`: Input data for updating contact information
+
+**Main Operations:**
+
+- Get all contact cards
+- Create new contact card
+- Update contact card information
+- Delete contact card
+
+#### PlatformContact (platform-contact)
+
+Platform-specific account information for contacts, with one-to-many relationship to ContactCard:
+
+**Data Model:**
+
+```typescript
+interface PlatformContact {
+  id: UUID; // Unique identifier
+  contact_card_id: UUID; // Foreign key to ContactCard
+  platform: PlatformEnum; // Platform type (Telegram/Discord/Matrix)
+  platform_user_id: string; // User ID on that platform
+  dm_room_id: string; // Direct message room ID
+}
+
+enum PlatformEnum {
+  TELEGRAM = "Telegram",
+  DISCORD = "Discord",
+  MATRIX = "Matrix",
+}
+```
+
+**API Data Structures:**
+
+- `PlatformContactResponse`: Complete data returned to frontend
+- `PlatformContactCreate`: Input data for creating new platform contacts
+- `PlatformContactUpdate`: Input data for updates (platform_user_id and dm_room_id only)
+
+**Main Operations:**
+
+- Get all platform contacts for a specific ContactCard
+- Create new platform contact information
+- Update platform contact information
+- Delete platform contact information
+
+**Relationship Structure:**
+
+```
+ContactCard (1) ←→ (many) PlatformContact
+```
+
+- One contact can have multiple platform accounts
+- Each platform account belongs to one contact
+
 ## Development Notes
 
 ### Environment Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
     - `message/` - Message display components
   - `lib/` - Utility libraries
     - `matrix-api/` - Matrix protocol API wrappers
+    - `contacts-server-api/` - Contacts server API integration
   - `contexts/` - React context providers
   - `hooks/` - Custom React hooks
 
@@ -65,7 +66,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 #### Component Organization
 
 - UI components follow shadcn/ui patterns with Radix UI primitives
-- Custom components in feature-specific folders (room-chat, message)
+- Custom components in feature-specific folders (room-chat, message, card-list)
 - Theme support via `next-themes` with dark mode default
 
 #### State Management
@@ -86,11 +87,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Invite system and room settings
 - Bridge network icon support
 
-## Planned Features
+## Contact Management System
 
-### Contact Management System
-
-The application will include a contact management system with two main entities:
+The application includes a contact management system with two main entities, now implemented with full API integration:
 
 #### ContactCard (contact-cards)
 
@@ -164,6 +163,50 @@ ContactCard (1) ←→ (many) PlatformContact
 - One contact can have multiple platform accounts
 - Each platform account belongs to one contact
 
+### API Integration
+
+The contacts system is implemented with a dedicated API client:
+
+**Location:** `app/lib/contacts-server-api/`
+
+**Structure:**
+
+- `index.ts` - Axios client with authentication interceptors
+- `types.ts` - TypeScript definitions for all data models
+- `contacts.ts` - Contact card CRUD operations
+- `platform-contacts.ts` - Platform contact CRUD operations
+- `bridge/telegram.ts` - Telegram-specific bridge operations
+
+**Authentication:**
+
+- Uses Bearer token authentication via request interceptors
+- Integrates with existing auth cookie system
+- Configurable via `VITE_CONTACTS_SERVER` environment variable
+
+**Error Handling:**
+
+- Axios-based HTTP client with 10-second timeout
+- Standard HTTP error responses with proper typing
+
+### UI Components
+
+**Contact Card Components** (`app/components/card-list/`):
+
+- `card-list.tsx` - Main container for contact cards display
+- `contact-card.tsx` - Individual contact card component
+- `create-card-dialog.tsx` - Form dialog for creating new contacts
+
+**Features:**
+
+- Form validation using react-hook-form with Zod schema
+- File upload support for contact avatars
+- Responsive card grid layout
+- Loading states and error handling
+
+**Routes:**
+
+- `_home.cards.tsx` - Main contacts page with card list integration
+
 ## Development Notes
 
 ### Environment Setup
@@ -171,6 +214,10 @@ ContactCard (1) ←→ (many) PlatformContact
 - Node.js v22+ required
 - Pre-commit hooks configured with lint-staged
 - ESLint + Prettier for code quality
+
+**Environment Variables:**
+
+- `VITE_CONTACTS_SERVER` - Base URL for the contacts API server
 
 ### Docker Support
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,8 +101,8 @@ Basic contact information cards containing:
 interface ContactCard {
   id: UUID; // Unique identifier
   contact_name: string; // Contact name
-  nickname?: string; // Optional nickname
-  contact_avatar_url?: string; // Optional avatar URL
+  nickname: string | null; // Optional nickname (backend uses null, not undefined)
+  contact_avatar_url: string | null; // Optional avatar URL (backend uses null, not undefined)
 }
 ```
 
@@ -193,15 +193,27 @@ The contacts system is implemented with a dedicated API client:
 **Contact Card Components** (`app/components/card-list/`):
 
 - `card-list.tsx` - Main container for contact cards display
-- `contact-card.tsx` - Individual contact card component
+- `contact-card.tsx` - Individual contact card component (clickable with dialog integration)
+- `contact-card-dialog.tsx` - Full-featured dialog for viewing, editing, and deleting contacts
 - `create-card-dialog.tsx` - Form dialog for creating new contacts
 
 **Features:**
 
-- Form validation using react-hook-form with Zod schema
-- File upload support for contact avatars
-- Responsive card grid layout
-- Loading states and error handling
+- **Contact Card Interaction**: Click any contact card to open detailed view dialog
+- **Full CRUD Operations**: View, edit, and delete contact cards through the dialog interface
+- **Platform Account Management**: Add, edit, and delete platform-specific contact information
+- **Form Validation**: Uses react-hook-form with Zod schema validation
+- **Accessibility**: Semantic button elements with proper ARIA labels and keyboard navigation
+- **Responsive Layout**: Card grid layout with hover effects and loading states
+- **Error Handling**: Consistent error messaging using shadcn/ui Alert components
+
+**Dialog Features:**
+
+- Toggle between view and edit modes for contact information
+- Complete platform account management (Discord, Telegram, Matrix)
+- Delete confirmation and state management
+- Form validation and error display
+- Loading states for all async operations
 
 **Routes:**
 
@@ -217,9 +229,128 @@ The contacts system is implemented with a dedicated API client:
 
 **Environment Variables:**
 
+- `VITE_HOME_SERVER` - Matrix homeserver URL for Matrix protocol integration
 - `VITE_CONTACTS_SERVER` - Base URL for the contacts API server
+
+### Data Consistency Guidelines
+
+- When there are significant structural changes, please remember to check after making modifications whether the data matches what's in memory, and check if there is any outdated data or missing data that needs to be updated.
 
 ### Docker Support
 
 - Dockerfile available for containerized deployment
 - Production builds serve on port 3000
+
+### Language Guidelines
+
+- In default, use English to write comment and display UI.
+
+## Error Message UI Design Pattern
+
+When displaying error messages in forms or dialogs, use the shadcn/ui Alert component pattern for consistent and comfortable user experience:
+
+### Pattern
+
+```tsx
+import { Alert, AlertDescription } from "~/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
+
+// Error message display
+{
+  error && (
+    <Alert>
+      <AlertTriangle className="h-4 w-4" />
+      <AlertDescription>{error}</AlertDescription>
+    </Alert>
+  );
+}
+```
+
+### Benefits
+
+- Consistent with design system (same as Danger zone in room-settings)
+- Proper contrast and readability in both light/dark modes
+- Professional appearance with appropriate warning icon
+- No harsh bright backgrounds that strain eyes
+
+### Example Reference
+
+See `app/components/room-chat/room-settings.tsx` lines 188-193 for the original pattern implementation.
+
+## RoomAvatar Component System
+
+### Overview
+
+The application uses a unified `RoomAvatar` component (`app/components/ui/room-avatar.tsx`) for displaying Matrix room avatars consistently across the entire application. This component provides automatic avatar loading, memory management, and fallback handling.
+
+### Component API
+
+```tsx
+interface RoomAvatarProps {
+  roomId: string; // Matrix room ID
+  roomName: string; // Room display name for fallback
+  fallbackAvatarUrl?: string | null; // Optional fallback avatar URL
+  className?: string; // Custom CSS classes
+  fallbackClassName?: string; // Custom fallback text classes
+  alt?: string; // Custom alt text
+}
+
+// Usage example
+<RoomAvatar
+  roomId={room.roomId}
+  roomName={room.roomName}
+  fallbackAvatarUrl={room.roomAvatar}
+  className="size-8"
+  fallbackClassName="text-sm"
+/>;
+```
+
+### Features
+
+- **Automatic Loading**: Uses `useRoomAvatar` hook internally to fetch Matrix room avatars
+- **Memory Management**: Automatically handles blob URL creation and cleanup
+- **Consistent Fallbacks**: Uses `avatarFallback()` function for uniform fallback text generation
+- **Flexible Styling**: Supports custom classes for different sizes and contexts
+- **Architecture Compliance**: Component layer doesn't directly depend on Matrix client
+
+### Implementation Locations
+
+The RoomAvatar component is integrated across all room avatar display locations:
+
+- ✅ `app/components/ui/dm-room-selector.tsx` - DM room selection (both selected and dropdown items)
+- ✅ `app/components/room-list/room-list-button.tsx` - Room list buttons
+- ✅ `app/components/room-chat/room-chat.tsx` - Chat header
+- ✅ `app/components/card-list/contact-card-dialog.tsx` - DM room display in contact dialogs
+
+### Benefits
+
+- **Consistency**: All room avatars use the same loading and display logic
+- **Maintainability**: Single component for all room avatar needs
+- **Performance**: Automatic memory management prevents memory leaks
+- **Developer Experience**: Simple API reduces boilerplate code
+
+### Usage Guidelines
+
+1. **Always use RoomAvatar for Matrix room avatars** - Do not use raw Avatar components for room avatars
+2. **Provide fallback URLs when available** - Pass room.roomAvatar or similar as fallbackAvatarUrl
+3. **Use appropriate sizing** - Common sizes: size-6, size-8, size-12
+4. **Consider context for fallback text size** - Use text-xs for small avatars, text-sm for medium
+
+# important-instruction-reminders
+
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User.
+
+# RoomAvatar Component Implementation Status
+
+**Status**: ✅ Complete - All room avatar displays now use the unified RoomAvatar component
+**Last Updated**: 2025-08-25
+
+# important-instruction-reminders
+
+Do what has been asked; nothing more, nothing less.
+NEVER create files unless they're absolutely necessary for achieving your goal.
+ALWAYS prefer editing an existing file to creating a new one.
+NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User.

--- a/app/lib/contacts-server-api/contacts.ts
+++ b/app/lib/contacts-server-api/contacts.ts
@@ -1,50 +1,37 @@
 import contactsApi from ".";
+import type {
+  ContactCardResponse,
+  ContactCardCreate,
+  ContactCardUpdate,
+} from "./types";
 
-interface contactCard {
-  id: string;
-  contact_name: string;
-  nickname: string;
-  contact_avatar_url: string;
+export async function getAllContactCards(): Promise<ContactCardResponse[]> {
+  const response = await contactsApi.get("/api/contact-cards");
+  return response.data;
+}
+export async function createContactCards(
+  data: ContactCardCreate,
+): Promise<ContactCardResponse> {
+  const response = await contactsApi.post("/api/contact-cards", data);
+  return response.data;
 }
 
-export function getAllContactCards(): Promise<contactCard[]> {
-  return contactsApi
-    .get("/api/contact-cards")
-    .then((response) => response.data);
-}
-export function createContactCards(
-  contact_name: string,
-  nickname: string,
-  contact_avatar_url: string,
-): Promise<contactCard> {
-  return contactsApi
-    .post("/api/contact-cards", {
-      contact_name,
-      nickname,
-      contact_avatar_url,
-    })
-    .then((response) => response.data);
-}
-
-export function updateContactCard(
+export async function updateContactCard(
   contact_card_id: string,
-  contact_name: string,
-  nickname: string,
-  contact_avatar_url: string,
-): Promise<contactCard> {
-  return contactsApi
-    .put(`/api/contact-cards/${contact_card_id}`, {
-      contact_name,
-      nickname,
-      contact_avatar_url,
-    })
-    .then((response) => response.data);
+  data: ContactCardUpdate,
+): Promise<ContactCardResponse> {
+  const response = await contactsApi.put(
+    `/api/contact-cards/${contact_card_id}`,
+    data,
+  );
+  return response.data;
 }
 
-export function deleteContactCard(
+export async function deleteContactCard(
   contact_card_id: string,
 ): Promise<{ message: string }> {
-  return contactsApi
-    .delete(`/api/contact-cards/${contact_card_id}`)
-    .then((response) => response.data);
+  const response = await contactsApi.delete(
+    `/api/contact-cards/${contact_card_id}`,
+  );
+  return response.data;
 }

--- a/app/lib/contacts-server-api/contacts.ts
+++ b/app/lib/contacts-server-api/contacts.ts
@@ -6,13 +6,13 @@ import type {
 } from "./types";
 
 export async function getAllContactCards(): Promise<ContactCardResponse[]> {
-  const response = await contactsApi.get("/api/contact-cards");
+  const response = await contactsApi.get("/api/contact-cards/");
   return response.data;
 }
 export async function createContactCards(
   data: ContactCardCreate,
 ): Promise<ContactCardResponse> {
-  const response = await contactsApi.post("/api/contact-cards", data);
+  const response = await contactsApi.post("/api/contact-cards/", data);
   return response.data;
 }
 

--- a/app/lib/contacts-server-api/platform-contacts.ts
+++ b/app/lib/contacts-server-api/platform-contacts.ts
@@ -1,52 +1,40 @@
 import contactsApi from ".";
-
-interface platformContact {
-  id: string;
-  contact_card_id: string;
-  platform: string;
-  dm_room_id: string;
-  platform_user_id: string;
-}
-export function getPlatformContacts(
+import type {
+  PlatformContactResponse,
+  PlatformContactCreate,
+  PlatformContactUpdate,
+} from "./types";
+export async function getPlatformContacts(
   contact_card_id: string,
-): Promise<platformContact[]> {
-  return contactsApi
-    .get(`/api/platform-contacts/${contact_card_id}`)
-    .then((response) => response.data);
+): Promise<PlatformContactResponse[]> {
+  const response = await contactsApi.get(
+    `/api/platform-contacts/${contact_card_id}`,
+  );
+  return response.data;
 }
 
-export function createPlatformContact(
-  contact_card_id: string,
-  platform: string,
-  dm_room_id: string,
-  platform_user_id: string,
-): Promise<platformContact> {
-  return contactsApi
-    .post(`/api/platform-contacts/`, {
-      contact_card_id,
-      platform,
-      dm_room_id,
-      platform_user_id,
-    })
-    .then((response) => response.data);
+export async function createPlatformContact(
+  data: PlatformContactCreate,
+): Promise<PlatformContactResponse> {
+  const response = await contactsApi.post(`/api/platform-contacts/`, data);
+  return response.data;
 }
 
-export function updatePlatformContact(
+export async function updatePlatformContact(
   platform_contact_id: string,
-  dm_room_id: string,
-  platform_user_id: string,
-): Promise<platformContact> {
-  return contactsApi
-    .put(`/api/platform-contacts/${platform_contact_id}`, {
-      dm_room_id,
-      platform_user_id,
-    })
-    .then((response) => response.data);
+  data: PlatformContactUpdate,
+): Promise<PlatformContactResponse> {
+  const response = await contactsApi.put(
+    `/api/platform-contacts/${platform_contact_id}`,
+    data,
+  );
+  return response.data;
 }
-export function deletePlatformContact(
+export async function deletePlatformContact(
   platform_contact_id: string,
 ): Promise<{ message: string }> {
-  return contactsApi
-    .delete(`/api/platform-contacts/${platform_contact_id}`)
-    .then((response) => response.data);
+  const response = await contactsApi.delete(
+    `/api/platform-contacts/${platform_contact_id}`,
+  );
+  return response.data;
 }

--- a/app/lib/contacts-server-api/types.ts
+++ b/app/lib/contacts-server-api/types.ts
@@ -7,8 +7,8 @@ export enum PlatformEnum {
 export interface ContactCard {
   id: string; // UUID
   contact_name: string;
-  nickname?: string;
-  contact_avatar_url?: string;
+  nickname: string | null;
+  contact_avatar_url: string | null;
 }
 
 export interface PlatformContact {

--- a/app/lib/contacts-server-api/types.ts
+++ b/app/lib/contacts-server-api/types.ts
@@ -1,0 +1,32 @@
+export enum PlatformEnum {
+  TELEGRAM = "Telegram",
+  DISCORD = "Discord",
+  MATRIX = "Matrix",
+}
+
+export interface ContactCard {
+  id: string; // UUID
+  contact_name: string;
+  nickname?: string;
+  contact_avatar_url?: string;
+}
+
+export interface PlatformContact {
+  id: string; // UUID
+  contact_card_id: string; // Foreign key to ContactCard
+  platform: PlatformEnum;
+  platform_user_id: string;
+  dm_room_id: string;
+}
+
+// API Data Structures
+export type ContactCardResponse = ContactCard;
+export type ContactCardCreate = Omit<ContactCard, "id">;
+export type ContactCardUpdate = Omit<ContactCard, "id">;
+
+export type PlatformContactResponse = PlatformContact;
+export type PlatformContactCreate = Omit<PlatformContact, "id">;
+export type PlatformContactUpdate = Pick<
+  PlatformContact,
+  "platform_user_id" | "dm_room_id"
+>;

--- a/app/lib/dm-room-utils.ts
+++ b/app/lib/dm-room-utils.ts
@@ -2,6 +2,7 @@ import type { Room } from "matrix-js-sdk";
 import { client } from "~/lib/matrix-api/client";
 import type { PlatformEnum } from "~/lib/contacts-server-api/types";
 import { detectPlatform } from "~/lib/matrix-api/utils";
+import { isDMRoom } from "./matrix-api/room";
 
 export interface DMRoomInfo {
   roomId: string;
@@ -10,14 +11,6 @@ export interface DMRoomInfo {
   platform: PlatformEnum;
   platformUserId?: string;
   otherUserId?: string;
-}
-
-/**
- * Check if a room is a DM room (2 members only)
- */
-export function isDMRoom(room: Room): boolean {
-  const members = room.getJoinedMembers();
-  return members.length === 2;
 }
 
 /**

--- a/app/lib/dm-room-utils.ts
+++ b/app/lib/dm-room-utils.ts
@@ -1,0 +1,90 @@
+import type { Room } from "matrix-js-sdk";
+import { client } from "~/lib/matrix-api/client";
+import type { PlatformEnum } from "~/lib/contacts-server-api/types";
+import { detectPlatform } from "~/lib/matrix-api/utils";
+
+export interface DMRoomInfo {
+  roomId: string;
+  roomName: string;
+  roomAvatar?: string;
+  platform: PlatformEnum;
+  platformUserId?: string;
+  otherUserId?: string;
+}
+
+/**
+ * Check if a room is a DM room (2 members only)
+ */
+export function isDMRoom(room: Room): boolean {
+  const members = room.getJoinedMembers();
+  return members.length === 2;
+}
+
+/**
+ * Get the other user's ID in a DM room
+ */
+export function getOtherUserId(room: Room): string | undefined {
+  if (!isDMRoom(room)) return undefined;
+
+  const myUserId = client.client?.getUserId();
+  if (!myUserId) return undefined;
+
+  const members = room.getJoinedMembers();
+  const otherMember = members.find((member) => member.userId !== myUserId);
+  return otherMember?.userId;
+}
+
+/**
+ * Parse platform user ID from Matrix user ID
+ * Format: {platform}_{platform_user_id}:{host_name}
+ */
+export function parsePlatformUserId(
+  matrixUserId: string,
+  platform: PlatformEnum,
+): string {
+  if (platform === "Matrix") {
+    return matrixUserId;
+  }
+
+  // Extract the local part before the colon
+  const localPart = matrixUserId.split(":")[0];
+  if (localPart.startsWith("@")) {
+    const withoutAt = localPart.substring(1);
+
+    // For bridged users, format is usually platform_userid
+    const platformPrefix = platform.toLowerCase() + "_";
+    if (withoutAt.startsWith(platformPrefix)) {
+      return withoutAt.substring(platformPrefix.length);
+    }
+
+    // Fallback: return the whole local part without @
+    return withoutAt;
+  }
+
+  return matrixUserId;
+}
+
+/**
+ * Get all DM rooms with their platform information
+ */
+export function getDMRooms(rooms: Room[]): DMRoomInfo[] {
+  return rooms
+    .filter((room) => isDMRoom(room))
+    .map((room) => {
+      const platform = detectPlatform(room);
+      const otherUserId = getOtherUserId(room);
+      const platformUserId = otherUserId
+        ? parsePlatformUserId(otherUserId, platform)
+        : undefined;
+
+      return {
+        roomId: room.roomId,
+        roomName: room.name || `DM with ${otherUserId || "Unknown"}`,
+        roomAvatar:
+          room.getAvatarUrl(room.client.baseUrl, 64, 64, "crop") || undefined,
+        platform,
+        platformUserId,
+        otherUserId,
+      };
+    });
+}

--- a/app/lib/env-config-helper.ts
+++ b/app/lib/env-config-helper.ts
@@ -1,3 +1,7 @@
 export const HOME_SERVER = import.meta.env.VITE_HOME_SERVER || "matrix.org";
+
+// 在開發模式使用 Vite proxy（相對路徑），生產模式直接連接 server
 export const CONTACTS_SERVER =
-  import.meta.env.VITE_CONTACTS_SERVER || "matrix.org";
+  import.meta.env.MODE === "development"
+    ? "" // 使用 Vite proxy 避免 CORS 問題
+    : import.meta.env.VITE_CONTACTS_SERVER || "http://localhost:8000";

--- a/app/lib/matrix-api/utils.ts
+++ b/app/lib/matrix-api/utils.ts
@@ -1,6 +1,5 @@
 import { getHttpUriForMxc } from "matrix-js-sdk/src/content-repo";
 import * as sdk from "matrix-js-sdk";
-import { EventTimeline, type Room } from "matrix-js-sdk";
 import { client } from "./client";
 import type { PlatformEnum } from "~/lib/contacts-server-api/types";
 
@@ -341,10 +340,10 @@ export async function getImageObjectUrl(
 /**
  * Detect platform from bridge information in a Matrix room
  */
-export function detectPlatform(room: Room): PlatformEnum {
+export function detectPlatform(room: sdk.Room): PlatformEnum {
   const bridgeStateEvents = room
     .getLiveTimeline()
-    .getState(EventTimeline.FORWARDS)
+    .getState(sdk.EventTimeline.FORWARDS)
     ?.getStateEvents("m.bridge");
 
   if (!bridgeStateEvents || bridgeStateEvents.length === 0) {
@@ -353,9 +352,9 @@ export function detectPlatform(room: Room): PlatformEnum {
 
   const content = bridgeStateEvents[0].getContent();
   const protocol = content?.protocol?.id;
-
   switch (protocol) {
     case "discord":
+    case "discordgo":
       return "Discord" as PlatformEnum;
     case "telegram":
       return "Telegram" as PlatformEnum;

--- a/app/lib/matrix-api/utils.ts
+++ b/app/lib/matrix-api/utils.ts
@@ -1,6 +1,8 @@
 import { getHttpUriForMxc } from "matrix-js-sdk/src/content-repo";
 import * as sdk from "matrix-js-sdk";
+import { EventTimeline, type Room } from "matrix-js-sdk";
 import { client } from "./client";
+import type { PlatformEnum } from "~/lib/contacts-server-api/types";
 
 /**
  * Get base URL from user ID
@@ -334,4 +336,30 @@ export async function getImageObjectUrl(
   const blob = await getImageBlob(mxcUrl);
   if (!blob) return undefined;
   return URL.createObjectURL(blob);
+}
+
+/**
+ * Detect platform from bridge information in a Matrix room
+ */
+export function detectPlatform(room: Room): PlatformEnum {
+  const bridgeStateEvents = room
+    .getLiveTimeline()
+    .getState(EventTimeline.FORWARDS)
+    ?.getStateEvents("m.bridge");
+
+  if (!bridgeStateEvents || bridgeStateEvents.length === 0) {
+    return "Matrix" as PlatformEnum;
+  }
+
+  const content = bridgeStateEvents[0].getContent();
+  const protocol = content?.protocol?.id;
+
+  switch (protocol) {
+    case "discord":
+      return "Discord" as PlatformEnum;
+    case "telegram":
+      return "Telegram" as PlatformEnum;
+    default:
+      return "Matrix" as PlatformEnum;
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,21 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+    server: {
+      proxy: {
+        "/api": {
+          target: env.VITE_CONTACTS_SERVER,
+          changeOrigin: true,
+          secure: false,
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
 ## 基礎架構與工具函數 (MES-135)

把那個大PR拆成四個小PR
感謝claude

  為聯絡人管理功能建立基礎設施和工具函數。

  ### 🏗️ 主要變更
  - **專案文檔**: 完整的 CLAUDE.md 架構說明和開發指引
  - **API 型別系統**: ContactCard/PlatformContact 型別定義和 API 客戶端
  - **Matrix 工具**: 平台檢測和 DM 房間管理工具函數
  - **開發環境**: CORS 代理設定和環境配置

  ### 📁 變更檔案 (8 個檔案，+574/-84 行)
  - `CLAUDE.md` - 專案文檔和架構指引
  - `app/lib/contacts-server-api/` - API 型別和客戶端函數
  - `app/lib/dm-room-utils.ts` - DM 房間工具函數
  - `app/lib/matrix-api/utils.ts` - 平台檢測工具
  - `vite.config.ts` - 開發代理配置
